### PR TITLE
Cpanm module could not use less than Python 2.6

### DIFF
--- a/packaging/language/cpanm.py
+++ b/packaging/language/cpanm.py
@@ -135,27 +135,27 @@ def _build_cmd_line(name, from_path, notest, locallib, mirror, mirror_only, inst
     # this code should use "%s" like everything else and just return early but not fixing all of it now.
     # don't copy stuff like this
     if from_path:
-        cmd = "{cpanm} {path}".format(cpanm=cpanm, path=from_path)
+        cmd = cpanm + " " + from_path
     else:
-        cmd = "{cpanm} {name}".format(cpanm=cpanm, name=name)
+        cmd = cpanm + " " + name
 
     if notest is True:
-        cmd = "{cmd} -n".format(cmd=cmd)
+        cmd = cmd + " -n"
 
     if locallib is not None:
-        cmd = "{cmd} -l {locallib}".format(cmd=cmd, locallib=locallib)
+        cmd = cmd + " -l " + locallib
 
     if mirror is not None:
-        cmd = "{cmd} --mirror {mirror}".format(cmd=cmd, mirror=mirror)
+        cmd = cmd + " --mirror " + mirror
 
     if mirror_only is True:
-        cmd = "{cmd} --mirror-only".format(cmd=cmd)
+        cmd = cmd + " --mirror-only"
 
     if installdeps is True:
-        cmd = "{cmd} --installdeps".format(cmd=cmd)
+        cmd = cmd + " --installdeps"
 
     if use_sudo is True:
-        cmd = "{cmd} --sudo".format(cmd=cmd)
+        cmd = cmd + " --sudo"
 
     return cmd
 


### PR DESCRIPTION
##### ISSUE TYPE
 Bugfix Pull Request

##### COMPONENT NAME
cpanm module

##### ANSIBLE VERSION
```
ansible 2.2.0 (devel 176a207c61) last updated 2016/05/26 16:33:26 (GMT +900)
  lib/ansible/modules/core: (detached HEAD fb77ab49ab) last updated 2016/05/26 16:33:54 (GMT +900)
  lib/ansible/modules/extras: (ikari7789-patch-1 63134a85d2) last updated 2016/05/26 16:52:39 (GMT +900)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Removed str.format() dependency to allow cpanm module to work on nodes with versions of Python less than 2.6.

Before
```
$ ansible node -m cpanm -a 'executable=/usr/local/bin/cpanm name=Encode@2.78 system_lib=yes' --become --become-user=root --ask-become-pass
SUDO password:
node | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "",
    "module_stdout": "\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_f3wxXN/ansible_module_cpanm.py\", line 220, in ?\r\n    main()\r\n  File \"/tmp/ansible_f3wxXN/ansible_module_cpanm.py\", line 205, in main\r\n    cmd       = _build_cmd_line(name, from_path, notest, locallib, mirror, mirror_only, installdeps, cpanm, use_sudo)\r\n  File \"/tmp/ansible_f3wxXN/ansible_module_cpanm.py\", line 140, in _build_cmd_line\r\n    cmd = \"{cpanm} {name}\".format(cpanm=cpanm, name=name)\r\nAttributeError: 'str' object has no attribute 'format'\r\n",
    "msg": "MODULE FAILURE",
    "parsed": false
}
```

After
```
$ ansible node -m cpanm -a 'executable=/usr/local/bin/cpanm name=Encode@2.78 system_lib=yes' --become --become-user=root --ask-become-pass
SUDO password:
node | SUCCESS => {
    "binary": "/usr/local/bin/cpanm",
    "changed": true,
    "name": "Encode@2.78"
}
```